### PR TITLE
fix: encode search params

### DIFF
--- a/src/modules/request.js
+++ b/src/modules/request.js
@@ -4,9 +4,8 @@ export const sendRequest = (endpoint, payload, mode = 'browser', opts = {}) => {
     if (opts.encode_search_params) {
         // Ensure spaces are not replaced with +
         qs = Object.entries(payloadParsed)
-            .map(([key, value]) => `${key}=${value}`)
+            .map(([key, value]) => `${key}=${encodeURIComponent(value)}`)
             .join('&')
-        qs = encodeURIComponent(qs)
     } else {
         qs = new URLSearchParams(
             payloadParsed

--- a/src/modules/request.js
+++ b/src/modules/request.js
@@ -1,7 +1,7 @@
 export const sendRequest = (endpoint, payload, mode = 'browser', opts = {}) => {
-    const qs = new URLSearchParams(
+    const qs = encodeURIComponent(new URLSearchParams(
         JSON.parse(JSON.stringify(payload))
-    ).toString()
+    ).toString())
     if (mode === 'browser') {
         navigator?.sendBeacon([endpoint, qs].join('?'))
     } else {

--- a/src/modules/request.js
+++ b/src/modules/request.js
@@ -1,7 +1,10 @@
 export const sendRequest = (endpoint, payload, mode = 'browser', opts = {}) => {
-    const qs = encodeURIComponent(new URLSearchParams(
+    let qs = new URLSearchParams(
         JSON.parse(JSON.stringify(payload))
-    ).toString())
+    ).toString()
+    if (opts.encode_search_params) {
+        qs = encodeURIComponent(qs)
+    }
     if (mode === 'browser') {
         navigator?.sendBeacon([endpoint, qs].join('?'))
     } else {

--- a/src/modules/request.js
+++ b/src/modules/request.js
@@ -1,9 +1,16 @@
 export const sendRequest = (endpoint, payload, mode = 'browser', opts = {}) => {
-    let qs = new URLSearchParams(
-        JSON.parse(JSON.stringify(payload))
-    ).toString()
+    const payloadParsed = JSON.parse(JSON.stringify(payload))
+    let qs = ''
     if (opts.encode_search_params) {
+        // Ensure spaces are not replaced with +
+        qs = Object.entries(payloadParsed)
+            .map(([key, value]) => `${key}=${value}`)
+            .join('&')
         qs = encodeURIComponent(qs)
+    } else {
+        qs = new URLSearchParams(
+            payloadParsed
+        ).toString()
     }
     if (mode === 'browser') {
         navigator?.sendBeacon([endpoint, qs].join('?'))


### PR DESCRIPTION
fixes #23 

adds boolean flag to opts to enable encoding of search params

## Prior
```js
const payload = {
  cd_application_id: 'SST - Some Online Shop',
}

const payloadParsed = JSON.parse(JSON.stringify(payload))
const qs = new URLSearchParams(payloadParsed).toString()
console.log(decodeURIComponent(qs)) // cd_application_id=SST+-+Some+Online+Shop
```

## Now
```js
const payload = {
  cd_application_id: 'SST - Some Online Shop',
}

const opts = {
  encode_search_params: true,
}

const payloadParsed = JSON.parse(JSON.stringify(payload))
let qs = ''
if (opts.encode_search_params) {
  // Ensure spaces are not replaced with +
  qs = Object.entries(payloadParsed)
    .map(([key, value]) => `${key}=${encodeURIComponent(value)}`)
    .join('&')
} else {
  qs = new URLSearchParams(payloadParsed).toString()
}
console.log(decodeURIComponent(qs)) // cd_application_id=SST - Some Online Shop
```